### PR TITLE
Update to devpy 0.1 API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ write_to = "pyfvs/_version.py"
 
 [tool.devpy]
 package = 'pyfvs'  # used by pytest
-commands = ['devpy.build', 'devpy.test']
+commands = ['devpy.cmds.meson.build', 'devpy.cmds.meson.test']


### PR DESCRIPTION
Please note that `devpy` will soon be released as `spin` due to PyPi name availability.